### PR TITLE
Fix the problem with the URL

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,6 @@
 
 source "https://rubygems.org"
 
-ruby "2.0.0"
-
 gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
 gem "execjs"
 gem "pry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,38 +11,40 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.4.0)
-    coderay (1.1.0)
-    colorize (0.7.7)
+    coderay (1.1.1)
+    colorize (0.8.1)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    excon (0.45.4)
-    execjs (2.5.2)
-    faraday (0.9.1)
+    excon (0.51.0)
+    execjs (2.7.0)
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     faraday_middleware (0.10.0)
       faraday (>= 0.7.4, < 0.10)
     fuzzy_match (2.1.0)
     git (1.3.0)
     hashdiff (0.3.0)
-    hashie (3.4.2)
-    httpclient (2.6.0.1)
+    hashie (3.4.4)
+    httpclient (2.8.0)
     method_source (0.8.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.1.0)
     multipart-post (2.0.0)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
     open-uri-cached (0.0.5)
-    pry (0.10.1)
+    pkg-config (1.1.7)
+    pry (0.10.4)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     safe_yaml (1.0.4)
-    scraped_page_archive (0.1.0)
+    scraped_page_archive (0.3.1)
       git (~> 1.3.0)
       vcr-archive (~> 0.3.0)
     slop (3.6.0)
-    sqlite3 (1.3.10)
-    sqlite_magic (0.0.3)
+    sqlite3 (1.3.11)
+    sqlite_magic (0.0.6)
       sqlite3
     vcr (3.0.3)
     vcr-archive (0.3.0)
@@ -52,7 +54,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    wikidata-client (0.0.7)
+    wikidata-client (0.0.10)
       excon (~> 0.40)
       faraday (~> 0.9)
       faraday_middleware (~> 0.9)
@@ -72,8 +74,5 @@ DEPENDENCIES
   scraperwiki!
   wikidata-client (~> 0.0.7)
 
-RUBY VERSION
-   ruby 2.0.0p353
-
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/scraper.rb
+++ b/scraper.rb
@@ -7,8 +7,7 @@ require 'date'
 require 'open-uri'
 require 'pry'
 require 'resolv-replace'
-require 'scraped_page_archive/open-uri'
-
+require 'scraped_page_archive'
 # require 'open-uri/cached'
 
 class String
@@ -18,7 +17,7 @@ class String
 end
 
 def noko_for(url)
-  Nokogiri::HTML(open(url).read) 
+  Nokogiri::HTML(open(url).read)
 end
 
 def scrape_term(url)


### PR DESCRIPTION
This PR fixes the problem with the URL:

```
fatal: Not a git repository (or any of the parent directories): .git
Could not determine git repo for 'scraped_page_archive' to use.

See https://github.com/everypolitician/scraped_page_archive#usage for details.
/app/vendor/bundle/ruby/2.0.0/gems/vcr-3.0.3/lib/vcr/request_handler.rb:97:in `on_unhandled_request':  (VCR::Errors::UnhandledHTTPRequestError)
```

**But the scrapter is still broken**, as there are some cells in the table that contain no picture, for which the scraper gets a `nilclass` error when trying to call methods on that element, since there is no `img` element.
