### PR TITLE
Put the Ruby version back in the Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@
 
 source "https://rubygems.org"
 
+ruby "2.3.0"
+
 gem "scraperwiki", git: "https://github.com/openaustralia/scraperwiki-ruby.git", branch: "morph_defaults"
 gem "execjs"
 gem "pry"


### PR DESCRIPTION
It was removed previously to avoid conflicts with library versions in the Gemfile, but Morph now complains that the Gemfile doesn't have a Ruby version, so we are putting it back.
