### PR TITLE
Use the tidy method

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -14,6 +14,10 @@ class String
   def tidy
     self.gsub(/[[:space:]]+/, ' ').strip
   end
+
+  def tidy_non_greedy
+    self.gsub(/[[:space:]]/, ' ').strip
+  end
 end
 
 def noko_for(url)
@@ -28,12 +32,12 @@ def scrape_term(url)
     tds = tr.xpath('td')
     next if %w(vacant -vacant- ---).include?(tds[1].text.tidy.downcase)
     data = {
-      seatid: tds[0].text.gsub(/[[:space:]]/, ' ').strip,
-      name: tds[1].text.gsub(/[[:space:]]/, ' ').strip,
-      constituency: tds[2].text.gsub(/[[:space:]]/, ' ').strip.split('-').first,
+      seatid: tds[0].text.tidy_non_greedy,
+      name: tds[1].text.tidy_non_greedy,
+      constituency: tds[2].text.tidy_non_greedy.split('-').first,
       website: tds[3].xpath('a/@href').text,
       photograph: tds[3].xpath('a/img/@src').text,
-      party: tds[4].text.gsub(/[[:space:]]/, ' ').strip,
+      party: tds[4].text.tidy_non_greedy,
       term: 10,
       source: url.to_s,
     }

--- a/scraper.rb
+++ b/scraper.rb
@@ -14,10 +14,6 @@ class String
   def tidy
     self.gsub(/[[:space:]]+/, ' ').strip
   end
-
-  def tidy_non_greedy
-    self.gsub(/[[:space:]]/, ' ').strip
-  end
 end
 
 def noko_for(url)
@@ -32,12 +28,12 @@ def scrape_term(url)
     tds = tr.xpath('td')
     next if %w(vacant -vacant- ---).include?(tds[1].text.tidy.downcase)
     data = {
-      seatid: tds[0].text.tidy_non_greedy,
-      name: tds[1].text.tidy_non_greedy,
-      constituency: tds[2].text.tidy_non_greedy.split('-').first,
+      seatid: tds[0].text.tidy,
+      name: tds[1].text.tidy,
+      constituency: tds[2].text.tidy.split('-').first,
       website: tds[3].xpath('a/@href').text,
       photograph: tds[3].xpath('a/img/@src').text,
-      party: tds[4].text.tidy_non_greedy,
+      party: tds[4].text.tidy,
       term: 10,
       source: url.to_s,
     }


### PR DESCRIPTION
This PR uses the method that was already defined, `tidy`, to replace the chained String methods.

There was a difference between the regex in that method and the regex used in the code. The version in the `tidy` method was greedy:

``` ruby
gsub(/[[:space:]]+/, ' ').strip
```

but the regex in the code was non-greedy:

``` ruby
gsub(/[[:space:]]/, ' ').strip
```

So the substitution was done in two steps:
- first extracting what was already there into its own method, 
- then trying out the greedy version. 

The greedy version seems to have the same results, so the code now uses it.

This PR does not Close everypolitician/everypolitician-data#14909, although it might have been closed by PR #1 or #2, so I'm mentioning it here.
